### PR TITLE
Fix: Player selects a track when there are no tracks available

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -795,6 +795,12 @@ class ReactExoplayerView extends FrameLayout implements
         }
 
         TrackGroupArray groups = info.getTrackGroups(rendererIndex);
+
+        // You can't select a group when there is none
+        if (groups == null || groups.length == 0) {
+            return;
+        }
+
         int trackIndex = C.INDEX_UNSET;
 
         if (TextUtils.isEmpty(type)) {


### PR DESCRIPTION
Fixes an out of bounds error when there are no audio tracks available.